### PR TITLE
First stab at supporting elastic 2.x

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]]
-  :profiles {:provided {:dependencies [[org.elasticsearch/elasticsearch "1.4.0"]]}}
+  :profiles {:provided {:dependencies [[org.elasticsearch/elasticsearch "2.3.4"]]}}
   :lein-release {:deploy-via :clojars})

--- a/src/rubberlike/core.clj
+++ b/src/rubberlike/core.clj
@@ -8,8 +8,9 @@
 
 (defn settings
   [config]
-  (-> (org.elasticsearch.common.settings.ImmutableSettings/settingsBuilder)
+  (-> (org.elasticsearch.common.settings.Settings/settingsBuilder)
       (.put (stringify-map config))
+      (.put {"path.home" "/tmp/v"})
       .build))
 
 (defn health-response
@@ -88,7 +89,7 @@
 
 (defn stop
   [config]
-  (.stop (::node config))
+  (.close (::node config))
   (when (:rubberlike/temp-data-dir? config)
     (delete-recursively (:path.data config)))
   :stopped)


### PR DESCRIPTION
Would be great if rubberlike supported elastic 2.x. There were some breaking changes in the API that I've tried to find fixes for. 
This PR is an attempt to get the ball rolling on providing support for elastic 2.x. I'm fully expecting that some adjustments needs to be made for it to be acceptable :-)
- `path.home` is now a requirement it seems. Currently the PR "hardcodes" that to `/tmp/v` which is probably not great (: Maybe it should be supplied by the user and/or ... alternatively create a tmp dir on demand like it's currently done for the data directory
- obviously the readme would need to be updated as well 
- elastic 2 dumps a less than eppealing stacktrace in the log when it doesn't find JNA, maybe outside the scope of this lib to suggest how to resolve this, but I thought I'd mention it anyways
